### PR TITLE
feat: add admin page (development environment only) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_STORE
 
 .cache
 .env

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,16 +1,20 @@
 import {
+  json,
   Links,
   LinksFunction,
   LiveReload,
+  LoaderFunction,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLoaderData,
 } from "remix";
 import type { MetaFunction } from "remix";
 import globalStylesUrl from "~/styles/global.css";
 import favicon from "~/images/favicon.png";
 import featuredImage from "~/images/featured_image.png";
+import { getEnv } from "~/utils/env.server";
 
 export const meta: MetaFunction = () => {
   const title = "Ivan's shared documents";
@@ -36,7 +40,19 @@ export const links: LinksFunction = () => {
   ];
 };
 
+type LoaderData = {
+  ENV: ReturnType<typeof getEnv>;
+};
+
+export const loader: LoaderFunction = () => {
+  const data: LoaderData = {
+    ENV: getEnv(),
+  };
+  return json(data);
+};
+
 export default function App() {
+  const data = useLoaderData<LoaderData>();
   return (
     <html lang="en">
       <head>
@@ -47,6 +63,11 @@ export default function App() {
       <body>
         <Outlet />
         <ScrollRestoration />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.ENV = ${JSON.stringify(data.ENV)};`,
+          }}
+        />
         <Scripts />
         {process.env.NODE_ENV === "development" && <LiveReload />}
       </body>

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -20,7 +20,7 @@ export const links: LinksFunction = () => {
 };
 
 export const loader: LoaderFunction = async () => {
-  if (process.env.NODE_ENV !== "development") redirect("/");
+  if (process.env.NODE_ENV !== "development") return redirect("/");
 
   return await getPosts();
 };

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,0 +1,30 @@
+import { Link, LoaderFunction, Outlet, redirect, useLoaderData } from "remix";
+import { Post } from "~/types/Post";
+import { getPosts } from "~/utils/posts.server";
+
+export const loader: LoaderFunction = async () => {
+  if (process.env.NODE_ENV !== "development") redirect("/");
+
+  return await getPosts();
+};
+
+export default function Admin() {
+  const posts = useLoaderData<Array<Post>>();
+  return (
+    <div className="admin">
+      <nav>
+        <h1>Admin</h1>
+        <ul>
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <Link to={`/admin/edit/${post.slug}`}>{post.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,6 +1,23 @@
-import { Link, LoaderFunction, Outlet, redirect, useLoaderData } from "remix";
+import {
+  Link,
+  LinksFunction,
+  LoaderFunction,
+  Outlet,
+  redirect,
+  useLoaderData,
+} from "remix";
 import { Post } from "~/types/Post";
 import { getPosts } from "~/utils/posts.server";
+import AdminStyles from "~/styles/admin.css";
+
+export const links: LinksFunction = () => {
+  return [
+    {
+      rel: "stylesheet",
+      href: AdminStyles,
+    },
+  ];
+};
 
 export const loader: LoaderFunction = async () => {
   if (process.env.NODE_ENV !== "development") redirect("/");
@@ -11,7 +28,7 @@ export const loader: LoaderFunction = async () => {
 export default function Admin() {
   const posts = useLoaderData<Array<Post>>();
   return (
-    <div className="admin">
+    <div className="admin-container">
       <nav>
         <h1>Admin</h1>
         <ul>

--- a/app/routes/admin/edit.$slug.tsx
+++ b/app/routes/admin/edit.$slug.tsx
@@ -1,14 +1,66 @@
-import { LoaderFunction, useLoaderData } from "remix";
-import { getPost } from "~/utils/posts.server";
+import {
+  ActionFunction,
+  Form,
+  json,
+  LoaderFunction,
+  redirect,
+  useLoaderData,
+} from "remix";
+import { PostUpdate } from "~/types/Post";
+import { editPost, getPostRaw } from "~/utils/posts.server";
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+
+  const id = formData.get("id") as string;
+  const title = formData.get("title") as string;
+  const markdown = formData.get("markdown") as string;
+  const slug = formData.get("slug") as string;
+
+  if (!title || !markdown || !slug) return json("Some fields are missing");
+
+  await editPost(id, { title, markdown, slug });
+
+  return redirect("/admin");
+};
 
 export const loader: LoaderFunction = async ({ params }) => {
   if (!params.slug) throw "`params.slug` was not found";
+  if (process.env.NODE_ENV !== "development") return redirect("/");
 
-  return await getPost(params.slug);
+  return await getPostRaw(params.slug);
 };
 
 export default function EditPost() {
-  const data = useLoaderData();
+  const data = useLoaderData<PostUpdate>();
   console.log(data);
-  return <h2>edit Post</h2>;
+  return (
+    <Form method="post">
+      <input type="hidden" name="id" value={data.id} />
+      <p>
+        <label>
+          Post Title:{" "}
+          <input type="text" name="title" defaultValue={data.title} />
+        </label>
+      </p>
+      <p>
+        <label>
+          Post Slug: <input type="text" name="slug" defaultValue={data.slug} />
+        </label>
+      </p>
+      <p>
+        <label htmlFor="markdown">Markdown:</label>
+        <br />
+        <textarea
+          id="markdown"
+          rows={20}
+          name="markdown"
+          defaultValue={data.markdown}
+        />
+      </p>
+      <p>
+        <button type="submit">Update Post</button>
+      </p>
+    </Form>
+  );
 }

--- a/app/routes/admin/edit.$slug.tsx
+++ b/app/routes/admin/edit.$slug.tsx
@@ -1,0 +1,14 @@
+import { LoaderFunction, useLoaderData } from "remix";
+import { getPost } from "~/utils/posts.server";
+
+export const loader: LoaderFunction = async ({ params }) => {
+  if (!params.slug) throw "`params.slug` was not found";
+
+  return await getPost(params.slug);
+};
+
+export default function EditPost() {
+  const data = useLoaderData();
+  console.log(data);
+  return <h2>edit Post</h2>;
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -14,7 +14,7 @@ export const links: LinksFunction = () => {
 };
 
 export const loader: LoaderFunction = async () => {
-  return getPosts();
+  return await getPosts();
 };
 
 export default function Index() {

--- a/app/styles/admin.css
+++ b/app/styles/admin.css
@@ -1,0 +1,5 @@
+.admin-container {
+  display: grid;
+  column-gap: 4rem;
+  grid-template-columns: 30rem 1fr;
+}

--- a/app/types/Post.ts
+++ b/app/types/Post.ts
@@ -1,3 +1,5 @@
+import { posts } from "@prisma/client";
+
 export type Post = {
   html: string;
   slug: string;
@@ -5,9 +7,10 @@ export type Post = {
   date: Date;
 };
 
-export type PostMarkdownMetadata = {
+export type PostUpdate = posts;
+
+export type UpdatePost = {
   title: string;
-  description: string;
-  iconSrc: string;
-  date: Date;
+  slug: string;
+  markdown: string;
 };

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -1,0 +1,16 @@
+export function getEnv() {
+  return {
+    NODE_ENV: process.env.NODE_ENV,
+  };
+}
+
+type ENV = ReturnType<typeof getEnv>;
+
+declare global {
+  // Declare a global ENV variable
+  var ENV: ENV;
+  // Augment the Window Interface
+  interface Window {
+    ENV: ENV;
+  }
+}

--- a/app/utils/posts.server.ts
+++ b/app/utils/posts.server.ts
@@ -1,12 +1,14 @@
 import { PrismaClient } from "@prisma/client";
 import { marked } from "marked";
-import { Post } from "~/types/Post";
+import { Post, PostUpdate, UpdatePost } from "~/types/Post";
 
 declare global {
   var prismaRead: ReturnType<typeof getClient> | undefined;
+  var prismaWrite: ReturnType<typeof getClient> | undefined;
 }
 
 const prismaRead = global.prismaRead ?? (global.prismaRead = getClient());
+const prismaWrite = global.prismaWrite ?? (global.prismaWrite = getClient());
 
 function getClient(): PrismaClient {
   const client = new PrismaClient();
@@ -32,4 +34,21 @@ export async function getPost(slug: string): Promise<Post | null> {
   const html = marked(foundPost.markdown);
 
   return { slug, title, html, date: foundPost.date };
+}
+
+export async function getPostRaw(slug: string): Promise<PostUpdate | null> {
+  const foundPost = await prismaRead.posts.findFirst({
+    where: {
+      slug,
+    },
+  });
+
+  if (!foundPost) return null;
+
+  return foundPost;
+}
+
+export async function editPost(postId: string, post: UpdatePost) {
+  console.log({ postId, post });
+  await prismaWrite.posts.update({ where: { id: postId }, data: post });
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// TODO: fix model name
 model posts {
   id       String   @id @default(auto()) @map("_id") @db.ObjectId
   date     DateTime @db.Date


### PR DESCRIPTION
The idea is to remove the friction of editing the existing posts directly from the db. Instead, this PR adds the `/admin` page where posts can be updated. 

Note: the admin form is ugly on purpose.